### PR TITLE
Ensure that all series values are floats

### DIFF
--- a/chart/drill-down.js
+++ b/chart/drill-down.js
@@ -52,11 +52,11 @@ export function createDrilldownDataStructure(rows) {
     const row = rows[i]
     const selector = row.selector
 
-    const drillDownData = row.drillDown.map(dr => { return [ dr.group, dr.value,] })
+    const drillDownData = row.drillDown.map(dr => { return [ dr.group, parseFloat(dr.value),] })
     drillDownSeries.push({ name: selector, id: selector, data: drillDownData, })
 
     const useDrillDown = (row.drillDown && row.drillDown.length > 0)
-    data.push({ name: selector, y: row.value, drilldown: (useDrillDown) ? selector : null, })
+    data.push({ name: selector, y: parseFloat(row.value), drilldown: (useDrillDown) ? selector : null, })
   }
 
   const series = []


### PR DESCRIPTION
There are instances I've run into where zeppelin (0.9.0-preview1) may interpret your numeric data as strings, **regardless of whether or not they are actually float values underneath**. This is unfortunate, as it also leads to [Highcharts Error 14](https://www.highcharts.com/errors/14/) trying to access the inner series in the chart. Putting in some `parseFloat` calls here is one easy way to ensure the data are numeric when passing into the HighCharts instance.